### PR TITLE
Update shebang to use env

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,7 @@
 # Created: Wed 16 Aug 2017 21:09:05 EEST too
 # Last modified: Fri 29 Apr 2022 16:44:59 +0300 too
 
-SHELL = /bin/sh
+SHELL = /usr/bin/env bash
 
 BIN := mxtx mxtx-io mxtx-rshd mxtx-rsh mxtx-socksproxy mxtx-dgramtunneld
 BIN += ldpreload-i2ubind.so ldpreload-i2uconnect5.so

--- a/addhost.sh
+++ b/addhost.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # $ addhost.sh -- add host to hosts-to-proxy for socksproxy to use $
 #

--- a/ioio.pl
+++ b/ioio.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # -*- mode: cperl; cperl-indent-level: 4 -*-
 # $ ioio.pl $
 #

--- a/mxtx-apu.sh
+++ b/mxtx-apu.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # mxtx acute program usage
 

--- a/mxtx-cp.sh
+++ b/mxtx-cp.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # -*- mode: shell-script; sh-basic-offset: 8; tab-width: 8 -*-
 # $ mxtx-cp.sh $
 #

--- a/mxtx-gitxxdiff.pl
+++ b/mxtx-gitxxdiff.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # -*- mode: cperl; cperl-indent-level: 4 -*-
 # $ mxtx-gitxxdiff.pl $
 #

--- a/mxtx-mosh.pl
+++ b/mxtx-mosh.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # -*- mode: cperl; cperl-indent-level: 4 -*-
 # $ mxtx-mosh.pl $
 #

--- a/mxtx-qpf-hack.pl
+++ b/mxtx-qpf-hack.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # -*- mode: cperl; cperl-indent-level: 8 -*-
 # $ mxtx-qpf-hack.pl $
 #

--- a/rsh-hook.tmpl
+++ b/rsh-hook.tmpl
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # -*- shell-script -*-
 
 # Copy this file as $HOME/.local/share/mxtx/rsh-hook (mode 755)

--- a/termtower-tmpl.sh
+++ b/termtower-tmpl.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # $ termtower-tmpl.sh $
 #

--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # -*- mode: shell-script; sh-basic-offset: 8; tab-width: 8 -*-
 # $ version.sh $
 #


### PR DESCRIPTION
This pull request replaces every `#!/bin/x` line in the CLI app with `#!/usr/bin/env x`

- This change makes the scripts more portable and ensures they work correctly on different systems (including NixOS which does not store binaries in /bin/)
- By using env, the script dynamically selects the appropriate shell based on the system environment, improving compatibility.

This fixes scripts for me, but I am not sure it is 100% the right way.

> Applications should note that the standard PATH to the shell cannot be assumed to be either /bin/sh or /usr/bin/sh
https://pubs.opengroup.org/onlinepubs/009695399/utilities/sh.html

> The env-mechanism is highly increasing convenience, and almost all systems nowadays provide /usr/bin/env. Yet, it cannot strictly assure "portability" of a script. 
https://www.in-ulm.de/~mascheck/various/shebang/#env

